### PR TITLE
fix: add proper exception handling and cooldown in xmr_chart, error handling in nick_loop

### DIFF
--- a/monerochad/commands/xmr_chart.py
+++ b/monerochad/commands/xmr_chart.py
@@ -1,5 +1,6 @@
 import discord
 from discord import app_commands
+from discord.ext import commands
 from io import BytesIO
 import mplfinance as mpf
 import pandas
@@ -24,41 +25,41 @@ INTERVAL_CHOICES = [
 	app_commands.Choice(name="15 days", value="21600;15d"),
 ]
 
-# Remember to update the command description too when changing the cooldown
-COOLDOWN_SECONDS = 15
-
-prevtime = 0.0
 
 def register(group: app_commands.Group):
 	
 	marketcolors = mpf.make_marketcolors(base_mpf_style="yahoo", wick="inherit")
 	mpf_style = mpf.make_mpf_style(base_mpf_style="yahoo", marketcolors=marketcolors)
-	
+
 	@group.command(name="chart", description="Get Monero price chart (has 15 second cooldown)")
 	@app_commands.describe(vs_val="Symbol of the coin to compare XMR to", interval_val="How much time should one candle represent")
 	@app_commands.choices(vs_val=VS_CHOICES, interval_val=INTERVAL_CHOICES)
 	@app_commands.rename(vs_val="vs", interval_val="interval")
+	@commands.cooldown(1, 15, commands.BucketType.user) ##
 	async def cmd(interaction: discord.Interaction, vs_val: str, interval_val: str):
-		global prevtime
-		nowtime = time.time()
-		delta_seconds = nowtime - prevtime
-		if delta_seconds < COOLDOWN_SECONDS:
-			again = COOLDOWN_SECONDS - delta_seconds
-			await interaction.response.send_message(
-				embed=common.fail_embed(f"The command is on cooldown. Try again in **{again:.1f}** seconds."),
-				ephemeral=True
-			)
-			return
-		prevtime = nowtime
 		await interaction.response.defer()
-		
-		pair, pair_display_name = vs_val.split(";")
-		interval, interval_display_name = interval_val.split(";")
+		try: ##
+		    pair, pair_display_name = vs_val.split(";")
+		    interval, interval_display_name = interval_val.split(";")
+		except ValueError:
+		    await interaction.followup.send(
+			embed=common.fail_embed("Invalid input format. Please provide both the pair and interval."),
+			ephemeral=True
+		    )
+		    return
 		
 		interval_minutes = int(interval)
 		since = (int(time.time()) - 30 * interval_minutes*60)
 		
-		candles = kraken.get_ohlc(pair, interval, since)
+		try: ##
+			candles = kraken.get_ohlc(pair, interval, since)
+		except Exception as e:
+		    await interaction.followup.send(
+			embed=common.fail_embed(f"Failed to retrieve chart data: {str(e)}"),
+			ephemeral=True
+		    )
+		    return
+
 		df = pandas.DataFrame([
 			{
 				"Date": candle.timestamp,
@@ -80,3 +81,10 @@ def register(group: app_commands.Group):
 		embed.set_footer(text=f"{pair_display_name} ({interval_display_name}) on Kraken")
 		
 		await interaction.followup.send(file=discord.File(fp=buf, filename="chart.png"), embed=embed)
+		
+	@cmd.error
+	async def cmd_error(ctx, error): ##
+		if isinstance(error, commands.CommandOnCooldown):
+			await ctx.send(embed=common.fail_embed(f"Please wait {error.retry_after:.1f} seconds before using this command again."), ephemeral=True)
+		else:
+			await ctx.send(embed=fail_embed(f"Unhandled error: {error}"), ephemeral=True)


### PR DESCRIPTION
- Added exception handling for splitting arguments, getting kraken data, replaced cooldown code with @commands.cooldown.
- Nick loop shouldn't break anymore if it fails in one guild (maybe permissions issue), if it fails to send DM to 'debug admins' (again, usually permissions/forbidden issue), it will simply continue after handling all errors (finally block)